### PR TITLE
refactor: update import paths for consistency across recipe-related f…

### DIFF
--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from './$types';
-import type { RecipeResponse } from '../lib/types/recipe.js';
-import { getServerApiUrl } from '../lib/config';
+import type { RecipeResponse } from '$lib/types/recipe.js';
+import { getServerApiUrl } from '$lib/config';
 
 export const load: PageServerLoad = async ({ fetch }) => {
 	try {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
-	import RecipeCard from '../lib/components/RecipeCard.svelte';
-	import SearchBar from '../lib/components/SearchBar.svelte';
-	import LoadingSpinner from '../lib/components/LoadingSpinner.svelte';
-	import CacheIndicator from '../lib/components/CacheIndicator.svelte';
-	import { recipesApi } from '../lib/api/recipes.js';
-	import { recipes, searchResults, isLoading, error, searchQuery, isSearching } from '../lib/stores/recipes.js';
-	import type { RecipeResponse, CacheInfo } from '../lib/types/recipe.js';
+	import RecipeCard from '$lib/components/RecipeCard.svelte';
+	import SearchBar from '$lib/components/SearchBar.svelte';
+	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+	import CacheIndicator from '$lib/components/CacheIndicator.svelte';
+	import { recipesApi } from '$lib/api/recipes.js';
+	import { recipes, searchResults, isLoading, error, searchQuery, isSearching } from '$lib/stores/recipes.js';
+	import type { RecipeResponse, CacheInfo } from '$lib/types/recipe.js';
 	import type { PageData } from './$types';
 
 	export let data: PageData;

--- a/frontend/src/routes/recipes/[source]/[id]/+page.server.ts
+++ b/frontend/src/routes/recipes/[source]/[id]/+page.server.ts
@@ -1,6 +1,6 @@
 import type { PageServerLoad } from './$types';
-import type { RecipeResponse } from '../../../../lib/types/recipe.js';
-import { getServerApiUrl } from '../../../../lib/config';
+import type { RecipeResponse } from '$lib/types/recipe.js';
+import { getServerApiUrl } from '$lib/config';
 
 export const load: PageServerLoad = async ({ params, fetch }) => {
 	const recipeId = parseInt(params.id);

--- a/frontend/src/routes/recipes/[source]/[id]/+page.svelte
+++ b/frontend/src/routes/recipes/[source]/[id]/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
-	import LoadingSpinner from '../../../../lib/components/LoadingSpinner.svelte';
-	import CacheIndicator from '../../../../lib/components/CacheIndicator.svelte';
-	import type { RecipeResponse } from '../../../../lib/types/recipe.js';
+	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
+	import CacheIndicator from '$lib/components/CacheIndicator.svelte';
+	import type { RecipeResponse } from '$lib/types/recipe.js';
 	import type { PageData } from './$types';
 
 	export let data: PageData;

--- a/frontend/src/routes/recipes/[source]/[id]/edit/+page.server.ts
+++ b/frontend/src/routes/recipes/[source]/[id]/edit/+page.server.ts
@@ -1,7 +1,7 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import type { RecipeResponse } from '../../../../../lib/types/recipe.js';
-import { getServerApiUrl } from '../../../../../lib/config';
+import type { RecipeResponse } from '$lib/types/recipe.js';
+import { getServerApiUrl } from '$lib/config';
 
 export const load: PageServerLoad = async ({ params, fetch }) => {
 	const recipeId = parseInt(params.id);

--- a/frontend/src/routes/recipes/[source]/[id]/edit/+page.svelte
+++ b/frontend/src/routes/recipes/[source]/[id]/edit/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
-	import RecipeForm from '../../../../../lib/components/RecipeForm.svelte';
-	import { recipesApi } from '../../../../../lib/api/recipes.js';
-	import type { RecipeResponse, RecipeRequest } from '../../../../../lib/types/recipe.js';
+	import RecipeForm from '$lib/components/RecipeForm.svelte';
+	import { recipesApi } from '$lib/api/recipes.js';
+	import type { RecipeResponse, RecipeRequest } from '$lib/types/recipe.js';
 	import type { PageData } from './$types';
 
 	export let data: PageData;

--- a/frontend/src/routes/recipes/internal/new/+page.svelte
+++ b/frontend/src/routes/recipes/internal/new/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import RecipeForm from '../../../../lib/components/RecipeForm.svelte';
-	import { recipesApi } from '../../../../lib/api/recipes.js';
-	import type { RecipeRequest } from '../../../../lib/types/recipe.js';
+	import RecipeForm from '$lib/components/RecipeForm.svelte';
+	import { recipesApi } from '$lib/api/recipes.js';
+	import type { RecipeRequest } from '$lib/types/recipe.js';
 
 	let isSubmitting = false;
 	let error: string | null = null;


### PR DESCRIPTION
…iles

- Changed import paths for `RecipeResponse` and other components to use the `$lib` alias, improving code readability and maintainability.
- Ensured uniformity in the import structure across various recipe-related pages and components.